### PR TITLE
add default viewport

### DIFF
--- a/generators/e2e/templates/cypress.json.ejs
+++ b/generators/e2e/templates/cypress.json.ejs
@@ -8,6 +8,8 @@
   "pluginsFile": "src/test/javascript/cypress/plugins/index.ts",
   "screenshotsFolder": "src/test/javascript/cypress/screenshots",
   "chromeWebSecurity": false,
+  "viewportWidth": 1200,
+  "viewportHeight": 720,
   "env": {
     "auth_base_url": "http://localhost:9080/auth",
     "auth_realm": "jhipster",


### PR DESCRIPTION
Some tests fail because Cypress does not display all the screen.

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
